### PR TITLE
Possible RoomView improvements

### DIFF
--- a/src/RoomView/RoomView.js
+++ b/src/RoomView/RoomView.js
@@ -53,6 +53,16 @@ class RoomView extends Component {
     }
   };
 
+  handleTimelineUpdate = (event, room, ts) => {
+    if(room.roomId === this.room.roomId){
+      const lastEventIndex = room.getLiveTimeline().getEvents().length - 1;
+      const { cursor, textInputFocus } = this.state;
+      this.setState({
+        cursor: textInputFocus ? lastEventIndex : cursor,
+      });
+    }
+  }
+
   centerCb = () => {
     const { message, cursor } = this.state;
     const { roomId } = this.props;
@@ -69,7 +79,7 @@ class RoomView extends Component {
           break;
         }
         window.mClient.sendTextMessage(roomId, message);
-        this.setState({ message: "", cursor: cursor + 1 });
+        this.setState({ message: "" });
         break;
       default:
         break;
@@ -106,10 +116,12 @@ class RoomView extends Component {
 
   componentDidMount() {
     document.addEventListener("keydown", this.handleKeyDown);
+    window.mClient.addListener("Room.timeline", this.handleTimelineUpdate);
   }
 
   componentWillUnmount() {
     document.removeEventListener("keydown", this.handleKeyDown);
+    window.mClient.removeListener("Room.timeline", this.handleTimelineUpdate);
   }
 
   render() {

--- a/src/RoomView/RoomView.js
+++ b/src/RoomView/RoomView.js
@@ -46,7 +46,7 @@ class RoomView extends Component {
       if (textInputFocus) {
         this.setState({ textInputFocus: false, cursor: lastEventIndex });
       } else if (cursor === 0) {
-        this.setState({ textInputFocus: true });
+        this.setState({ textInputFocus: true, cursor: lastEventIndex });
       } else {
         this.setState({ cursor: cursor - 1 });
       }

--- a/src/RoomView/RoomView.js
+++ b/src/RoomView/RoomView.js
@@ -64,7 +64,7 @@ class RoomView extends Component {
   }
 
   centerCb = () => {
-    const { message, cursor } = this.state;
+    const { message } = this.state;
     const { roomId } = this.props;
     switch (this.getCenterText()) {
       case "Select":


### PR DESCRIPTION

- RoomView now listens for timeline updates, so it can show new events
- When navigating **up** past the first event, the cursor is set to the last event:

| before up | -> | after up |
| --- | --- | --- |
| ![image](https://user-images.githubusercontent.com/82761048/144750024-2a6b5fef-cd19-4185-8f4a-b88332be960d.png) | **->** | ![image](https://user-images.githubusercontent.com/82761048/144750034-4194adbd-9278-453b-a00f-b3247ad4b2e7.png)
| text input not focused | | text input focused |