### PR TITLE
RoomView: Use ScrollIntoView with surrounding divs for each item

### DIFF
--- a/src/RoomView/RoomView.js
+++ b/src/RoomView/RoomView.js
@@ -158,10 +158,15 @@ class RoomView extends Component {
                 } else {
                   item = <UnsupportedEventItem senderId={senderId} />;
                 }
-                if (index === cursor) {
-                  item = <ScrollIntoView>{item}</ScrollIntoView>;
-                }
-                return item;
+
+                if(index === cursor && !textInputFocus)
+                  item.props.isFocused = true;
+
+                return (
+                  <ScrollIntoView shouldScroll={index === cursor}>
+                    {item}
+                  </ScrollIntoView>
+                );
               })}
           </div>
           <ChatTextInput

--- a/src/RoomView/RoomView.js
+++ b/src/RoomView/RoomView.js
@@ -53,6 +53,16 @@ class RoomView extends Component {
     }
   };
 
+  handleTimelineUpdate = (event, room, ts) => {
+    if(room.roomId === this.room.roomId){
+      const lastEventIndex = room.getLiveTimeline().getEvents().length - 1;
+      const { cursor, textInputFocus } = this.state;
+      this.setState({
+        cursor: textInputFocus ? lastEventIndex : cursor,
+      });
+    }
+  }
+
   centerCb = () => {
     const { message, cursor } = this.state;
     const { roomId } = this.props;
@@ -69,7 +79,7 @@ class RoomView extends Component {
           break;
         }
         window.mClient.sendTextMessage(roomId, message);
-        this.setState({ message: "", cursor: cursor + 1 });
+        this.setState({ message: "" });
         break;
       default:
         break;
@@ -106,10 +116,12 @@ class RoomView extends Component {
 
   componentDidMount() {
     document.addEventListener("keydown", this.handleKeyDown);
+    window.mClient.addListener("Room.timeline", this.handleTimelineUpdate);
   }
 
   componentWillUnmount() {
     document.removeEventListener("keydown", this.handleKeyDown);
+    window.mClient.removeListener("Room.timeline", this.handleTimelineUpdate);
   }
 
   render() {

--- a/src/RoomView/RoomView.js
+++ b/src/RoomView/RoomView.js
@@ -46,7 +46,7 @@ class RoomView extends Component {
       if (textInputFocus) {
         this.setState({ textInputFocus: false, cursor: lastEventIndex });
       } else if (cursor === 0) {
-        this.setState({ textInputFocus: true });
+        this.setState({ textInputFocus: true, cursor: lastEventIndex });
       } else {
         this.setState({ cursor: cursor - 1 });
       }

--- a/src/RoomView/RoomView.js
+++ b/src/RoomView/RoomView.js
@@ -64,7 +64,7 @@ class RoomView extends Component {
   }
 
   centerCb = () => {
-    const { message, cursor } = this.state;
+    const { message } = this.state;
     const { roomId } = this.props;
     switch (this.getCenterText()) {
       case "Select":

--- a/src/RoomView/ScrollIntoView.js
+++ b/src/RoomView/ScrollIntoView.js
@@ -1,13 +1,12 @@
-function ScrollIntoView({ children }) {
+function ScrollIntoView({ children, shouldScroll }) {
   if (children instanceof Array || !children) {
     throw new TypeError("There must be exactly one child. No less, no more!");
   }
-  children.props.isFocused = true;
   return (
     <div
-      ref={(div) => {
+      ref={shouldScroll ? ((div) => {
         if (div) div.scrollIntoView();
-      }}
+      }) : null}
     >
       {children}
     </div>


### PR DESCRIPTION
!!! Depends on: #15  

## Structural changes
Put all `RoomView` items inside a `ScrollIntoView`, and add a new `shouldScroll` parameter to `ScrollIntoView` that tells it whether to scroll.
## Functional changes
The last event is no longer visually focused when the text input is active (fixes #21). Possible performance improvement because the `divs` are no longer added and removed one-by-one, but loaded all at once.

| state | action | state | action | state |
| --- | --- | --- | --- | --- |
| ![image](https://user-images.githubusercontent.com/82761048/144890596-e06b3d88-e84a-405b-9f43-09230cacc63c.png) | **up** -> | ![image](https://user-images.githubusercontent.com/82761048/144890672-4aec8c08-ab29-486e-ba1a-9a268ea73924.png) | **up** -> | ![image](https://user-images.githubusercontent.com/82761048/144890807-7172c939-3a18-403d-8965-509ca41a1ec5.png) |