### PR TITLE
Fix audio/voice message (replaces PR 93)

### DIFF
--- a/src/MessageItems/IRCLikeMessageItem/IRCLikeMessageItem.tsx
+++ b/src/MessageItems/IRCLikeMessageItem/IRCLikeMessageItem.tsx
@@ -186,7 +186,7 @@ function IRCLikeMessageItemAudio({
         Duration: {createTextVNode(msToHigherScale(duration))}
         <br />
         Size: {createTextVNode(bytesToHigherScale(size))}
-        <audio src={url} autoPlay={false} />
+        <audio src={url} />
       </p>
     </div>
   );

--- a/src/MessageItems/IRCLikeMessageItem/IRCLikeMessageItem.tsx
+++ b/src/MessageItems/IRCLikeMessageItem/IRCLikeMessageItem.tsx
@@ -266,7 +266,7 @@ function IRCLikeMessageItem({
           text={content.body}
           duration={content.info.duration}
           size={content.info.size}
-          url={content.url.content_uri}
+          url={content.url}
           status={status}
           isFocused={isFocused}
         />


### PR DESCRIPTION
This PR replaces https://github.com/farooqkz/chooj/pull/93 because that PR was based off the wrong branch and included unwanted commits.

This PR fixes https://github.com/farooqkz/chooj/issues/90

This was tested on Nokia 8000 (20.00.17.01) and Nokia 8118 4G (17.00.17.01).

The IRCLikeMessageItem.tsx set a faulty url to the audio file, which caused errors.

After fixing this, all audio messages would start playing immediately once they had been downloaded.

This could be fixed by removing the autoPlay attribute from the audio tag in the Item. Autoplay is off by default but it was enabled because the "false" part after the attribute wasn't compiled as a string.