### PR TITLE
Login fix and improvements

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -5,7 +5,7 @@ import * as localforage from "localforage";
 import Matrix from "./Matrix";
 import Login from "./Login";
 import Guide from "./Guide";
-import { LoginData } from "./types";
+import { LoginData, WellKnown } from "./types";
 
 interface AppState {
   state: string | null;
@@ -15,12 +15,14 @@ interface AppState {
 
 class App extends Component<{}, AppState> {
   private loginData: null | LoginData;
+  private well_known: null | WellKnown;
   private timeout: null | number;
   public state: AppState;
 
   constructor(props: {}) {
     super(props);
     this.loginData = null;
+    this.well_known = null;
     this.timeout = null;
     this.state = {
       state: null,
@@ -34,6 +36,9 @@ class App extends Component<{}, AppState> {
       } else {
         this.setState({ state: "login" });
       }
+    });
+    localforage.getItem("well_known").then((well_known: unknown) => {
+        this.well_known = well_known as WellKnown;
     });
     localforage.getItem("guide").then((value: unknown) => {
       this.setState({ guide: Boolean(value) });
@@ -78,7 +83,7 @@ class App extends Component<{}, AppState> {
     }
 
     if (state === "matrix") {
-      return <Matrix data={this.loginData} />;
+      return <Matrix data={this.loginData} well_known={this.well_known} />;
     }
     alert("Some error occured. This must not happen");
     window.close();

--- a/src/Login.tsx
+++ b/src/Login.tsx
@@ -1,8 +1,5 @@
 import { Component } from "inferno";
-import * as localforage from "localforage";
 import { TextListItem, TextInput, Header, SoftKey, ListViewKeyed } from "KaiUI";
-import shared from "./shared";
-import { WellKnown } from "./types";
 import LoginWithQR from "./LoginWithQR";
 import LoginHandler from "./LoginHandler";
 import { LoginFlow } from "matrix-js-sdk/lib/@types/auth";

--- a/src/Login.tsx
+++ b/src/Login.tsx
@@ -121,7 +121,8 @@ class Login extends Component<{}, LoginState> {
 
   render() {
     if (this.state.loginWithQr) {
-      return <LoginWithQR />;
+      return <LoginWithQR loginHandler={this.loginHandler} />;
+      // return <LoginWithQR />;
     }
     let listViewChildren;
     switch (this.state.stage) {
@@ -147,7 +148,7 @@ class Login extends Component<{}, LoginState> {
           },
           {
             tertiary:
-              "Press Call button and scan a QR in the following format to login with QR code instead of typing all these(PASS = password authentication): PASS server_name username password",
+              "Press Call button and scan a QR in the following format to login with QR code instead of typing all these (PASS = password authentication): PASS server_name username password",
             type: "text",
             key: "qrHint",
           },

--- a/src/Login.tsx
+++ b/src/Login.tsx
@@ -127,6 +127,10 @@ class Login extends Component<{}, LoginState> {
           if (!this.homeserverUrl) {
             this.homeserverUrl = "https://" + this.homeserverName;
           }
+          localforage.setItem("well_known", {
+            "m.homeserver": {"base_url": this.homeserverUrl},
+            "m.identity_server": {"base_url": "https://vector.im"},  // TODO Where to infer this outside of actual .well-known?
+            })
           shared.mClient = createClient({
             baseUrl: this.homeserverUrl,
             fetchFn: customFetch,

--- a/src/Login.tsx
+++ b/src/Login.tsx
@@ -71,6 +71,11 @@ class Login extends Component<{}, LoginState> {
             this.password
           )
           .then((result: any) => {
+            if (result.well_known) {
+              localforage.setItem("well_known", result.well_known).then(() => {
+                console.log("Received a well_known from client login property. Updating previous settings.")
+              });
+            }
             localforage.setItem("login", result).then(() => {
               alert("Logged in as " + this.username);
               window.location = window.location;

--- a/src/LoginHandler.ts
+++ b/src/LoginHandler.ts
@@ -95,16 +95,24 @@ export default class LoginHandler {
       base_url = "https://" + name;
     } finally {
       this.base_url = base_url;
+      try {
+        shared.mClient = createClient({
+          baseUrl: base_url,
+          fetchFn: customFetch,
+        });
+        let result = await shared.mClient.loginFlows()
+        if (! result.flows) {
+          throw new Error("Got no flows");
+        }
+        this.loginFlows = result.flows;
+      } catch (e) {
+        alert(`No server found at ${base_url}`)
+        console.log(e);
+      }
       this.setWellKnown({
         "m.homeserver": {"base_url": base_url},
         "m.identity_server": {"base_url": "https://vector.im"},  // TODO Where to infer this outside of actual .well-known?
       })
-      shared.mClient = createClient({
-        baseUrl: base_url,
-        fetchFn: customFetch,
-      });
-      let result = await shared.mClient.loginFlows()
-      this.loginFlows = result.flows;
     }
   }
 }

--- a/src/LoginHandler.ts
+++ b/src/LoginHandler.ts
@@ -1,0 +1,53 @@
+import { fetch as customFetch } from "./fetch";
+import { WellKnown } from "./types";
+import { LoginFlow } from "matrix-js-sdk/lib/@types/auth";
+import * as localforage from "localforage";
+import { createClient } from "matrix-js-sdk";
+import shared from "./shared";
+
+export default class LoginHandler {
+  public base_url: string;
+  public homeserverName: string;
+  public username: string;
+  public password: string;
+  public loginFlows: LoginFlow[];
+
+  constructor() {
+    this.homeserverName = "";
+    this.username = "";
+    this.password = "";
+    this.loginFlows = [];
+    this.base_url = "";
+  }
+
+  public async findHomeserver(name: string) {
+    name = name.replace("https://", "");
+    name = name.replace("http://", "");
+    let base_url: string = "";
+    let well_known_url = `https://${name}/.well-known/matrix/client`;
+      try {
+      let r: Response = await fetch(well_known_url);
+      if (!r.ok) {
+        throw new Error("404");
+
+      }
+      let well_known: WellKnown = await r.json();
+      base_url = well_known["m.homeserver"].base_url;
+    } catch (e: any) {
+      console.log(`.well-known not found or malformed at ${well_known_url}`);
+      base_url = "https://" + name;
+    } finally {
+      this.base_url = base_url;
+      localforage.setItem("well_known", {
+        "m.homeserver": {"base_url": base_url},
+        "m.identity_server": {"base_url": "https://vector.im"},  // TODO Where to infer this outside of actual .well-known?
+      })
+      shared.mClient = createClient({
+        baseUrl: base_url,
+        fetchFn: customFetch,
+      });
+      let result = await shared.mClient.loginFlows()
+      this.loginFlows = result.flows;
+    }
+  }
+}

--- a/src/LoginHandler.ts
+++ b/src/LoginHandler.ts
@@ -20,9 +20,66 @@ export default class LoginHandler {
     this.base_url = "";
   }
 
+  private setWellKnown(well_known: WellKnown) {
+    return localforage.setItem("well_known", well_known);
+  }
+
+  public async doLogin(loginFlow: LoginFlow, loginData: any) {
+    // TODO implement more login flows
+    // Instead of implementing them one by one, consider using mClient.login
+    // and passing loginData (which needs to be properly formed according to their spec)
+    // (may or may not be a bad idea)
+    try {
+      let loginResult: any;
+      let username: string = `@${loginData.username}:${this.homeserverName}`;
+      switch (loginFlow.type) {
+        case "m.login.password":
+          let password: string = loginData.password;
+          loginResult = await shared.mClient
+            .loginWithPassword(username, password);
+          break;
+        default:
+          throw new Error("Unsupported");
+          break;
+      }
+      if (loginResult.well_known) {
+        this.setWellKnown(loginResult.well_known)
+        console.log("Received a well_known from client login property. Updating previous settings.")
+        console.log(loginResult.well_known)
+      }
+      await localforage.setItem("login", loginResult);
+      alert("Logged in as " + username);
+    } catch (e: any) {
+      let message: string;
+      switch (e.errcode) {
+        case "M_FORBIDDEN":
+          message = "Incorrect login credentials";
+          break;
+        case "M_USER_DEACTIVATED":
+          message = "This account has been deactivated";
+          break;
+        case "M_LIMIT_EXCEEDED":
+          const retry = Math.ceil(e.retry_after_ms / 1000);
+          message = `Too many requests! Retry after ${retry.toString()}`;
+          break;
+        default:
+          if (e.message === "Unsupported") {
+            message = "Login flow selected is unsupported"
+          } else if (e.errcode) {
+            message = e.errcode;
+          } else {
+            message = `Login failed for some unknown reason: ${e.message}`;
+          }
+          break;
+      }
+      throw new Error(message)
+    }
+  }
+
   public async findHomeserver(name: string) {
     name = name.replace("https://", "");
     name = name.replace("http://", "");
+    this.homeserverName = name;
     let base_url: string = "";
     let well_known_url = `https://${name}/.well-known/matrix/client`;
       try {
@@ -38,7 +95,7 @@ export default class LoginHandler {
       base_url = "https://" + name;
     } finally {
       this.base_url = base_url;
-      localforage.setItem("well_known", {
+      this.setWellKnown({
         "m.homeserver": {"base_url": base_url},
         "m.identity_server": {"base_url": "https://vector.im"},  // TODO Where to infer this outside of actual .well-known?
       })

--- a/src/Matrix.tsx
+++ b/src/Matrix.tsx
@@ -27,6 +27,7 @@ const vapidPublicKey =
 
 interface MatrixProps {
   data: any;
+  well_known: any;
 }
 
 interface Call {
@@ -321,10 +322,10 @@ class Matrix extends Component<MatrixProps, MatrixState> {
       userId: props.data.user_id,
       accessToken: props.data.access_token,
       deviceId: props.data.device_id,
-      baseUrl: props.data.well_known["m.homeserver"].base_url,
+      baseUrl: props.well_known["m.homeserver"].base_url,
       identityServer:
-        props.data.well_known["m.identity_server"] &&
-        props.data.well_known["m.identity_server"].base_url,
+        props.well_known["m.identity_server"] &&
+        props.well_known["m.identity_server"].base_url,
       //      store: new matrixcs.IndexedDBStore({ indexedDB: window.indexedDB, localStorage: window.localStorage }),
     });
     const client = shared.mClient;


### PR DESCRIPTION
For now, this PR fixes #89, including updating the well-known information if supplied by the client. I opted to insist on the "well_known" abstraction even when an actual `.well_known` file or property are not returned by the server. 

However, I only fixed the normal login flow. There seems to be a lot of duplicated code in `LoginWithQR.tsx`, and I have not touched the QR login yet.

I would like to refactor the code in `Login.tsx` and `LoginWithQR.tsx` by decoupling the actual login flow and logic from the presentation; something like a `LoginHelper` class to hold the logic, and then passing it to `Login.tsx` and `LoginWithQR.tsx` so that they use the same code underlying. 

DRY and all; this will be especially important as more login flows are added, both to be typed manually and scanned with the QR code.